### PR TITLE
Use param doc in method find_character_occurences

### DIFF
--- a/01_pride_and_predjudice.ipynb
+++ b/01_pride_and_predjudice.ipynb
@@ -142,7 +142,7 @@
     "    \"\"\"\n",
     "    \n",
     "    characters = Counter()\n",
-    "    for ent in processed_text.ents:\n",
+    "    for ent in doc.ents:\n",
     "        if ent.label_ == 'PERSON':\n",
     "            characters[ent.lemma_] += 1\n",
     "            \n",


### PR DESCRIPTION
In the method `find_character_occurences`, read characters from `doc` instead of directly reading from `processed_text`.